### PR TITLE
feat(tees-driver): Add "hover()" method support for the puppeteer driver

### DIFF
--- a/packages/tees-drivers/Drivers.d.ts
+++ b/packages/tees-drivers/Drivers.d.ts
@@ -9,6 +9,7 @@ interface $ {
     html(selector: string): string
     url(): sting
     click(selector: string, options?: Object): string
+    hover(selector: string, options?: Object): string
     type(selector: string, value: string, options?: Object): string
     waitForSelector(selector: string, options?: Object): Promise<?ElementHandle>
     waitForFrames(frameSelectors: string): Frame

--- a/packages/tees-drivers/src/puppeteer/index.js
+++ b/packages/tees-drivers/src/puppeteer/index.js
@@ -86,6 +86,12 @@ class Query extends BaseQuery {
     await this._node.click(_selector, options);
   }
 
+  async hover(selector, options = {}) {
+    await this.waitForSelector(selector, options);
+    const _selector = this.getSelector(selector);
+    await this._node.hover(_selector);
+  }
+
   async type(selector, value, options = {}) {
     const _selector = this.getSelector(selector, options);
     await this._node.type(_selector, value, options);


### PR DESCRIPTION
Since puppeteer supports "hover()" method and under some circumstance we need to simulate the mouse hovering behavior, so I created such a PR to support this method